### PR TITLE
Fix jshint

### DIFF
--- a/jqModal.js
+++ b/jqModal.js
@@ -209,7 +209,7 @@
 
 		});
 
-	}, function(h){
+	}, open = function(h){
 		// open: executes the onOpen callback + performs common tasks if successful
 
 		// transform legacy hash into new var shortcuts 

--- a/jqModal.js
+++ b/jqModal.js
@@ -11,36 +11,35 @@
  */
 
 (function($) {
-	
+
 	/**
 	 * Initialize a set of elements as "modals". Modals typically are popup dialogs,
-	 * notices, modal windows, &c. 
-	 * 
+	 * notices, modal windows, &c.
+	 *
 	 * @name jqm
 	 * @param options user defined options, augments defaults.
 	 * @type jQuery
 	 * @cat Plugins/jqModal
 	 */
-	
+
 	$.fn.jqm=function(options){
 		return this.each(function(){
 			var e = $(this),
 				jqm = e.data('jqm') || $.extend({ID: I++}, $.jqm.params),
 				o = $.extend(jqm,options);
-			
+
 			// add/extend options to modal and mark as initialized
 			e.data('jqm',o).addClass('jqm-init')[0]._jqmID = o.ID;
-			
+
 			// ... Attach events to trigger showing of this modal
 			o.trigger && e.jqmAddTrigger(o.trigger);
 		});
 	};
-	
-	
+
 	/**
 	 * Matching modals will have their jqmShow() method fired by attaching a
 	 *   onClick event to elements matching `trigger`.
-	 * 
+	 *
 	 * @name jqmAddTrigger
 	 * @param trigger a selector String, jQuery collection of elements, or a DOM element.
 	 */
@@ -50,8 +49,7 @@
 				err("jqmAddTrigger must be called on initialized modals");
 		});
 	};
-	
-	
+
 	/**
 	 * Matching modals will have their jqmHide() method fired by attaching an
 	 *   onClick event to elements matching `trigger`.
@@ -65,70 +63,67 @@
 				err("jqmAddClose must be called on initialized modals");
 		});
 	};
-	
-	
+
 	/**
 	 * Open matching modals (if not shown)
 	 */
 	$.fn.jqmShow=function(trigger){
 		return this.each(function(){ !this._jqmShown&&show($(this), trigger); });
 	};
-	
+
 	/**
 	 * Close matching modals
 	 */
 	$.fn.jqmHide=function(trigger){
 		return this.each(function(){ this._jqmShown&&hide($(this), trigger); });
 	};
-	
-	
+
 	// utility functions
-	
+
 	var
 		err = function(msg){
 			if(window.console && window.console.error) window.console.error(msg);
-		
-		
+
 	}, show = function(e, t){
-		
+
 		/**
 		 * e = modal element (as jQuery object)
 		 * t = triggering element
-		 * 
+		 *
 		 * o = options
 		 * z = z-index of modal
 		 * v = overlay element (as jQuery object)
 		 * h = hash (for jqModal <= r15 compatibility)
 		 */
-		
+
 		var o = e.data('jqm'),
 			t = t || window.event,
 			z = (parseInt(e.css('z-index'))),
 			z = (z > 0) ? z : 3000,
 			v = $('<div></div>').addClass(o.overlayClass).css({height:'100%',width:'100%',position:'fixed',left:0,top:0,'z-index':z-1,opacity:o.overlay/100}),
-		
+
 			// maintain legacy "hash" construct
 			h = {w: e, c: o, o: v, t: t};	
-			
+
 		e.css('z-index',z);
 
 		if(o.ajax){
 			var target = o.target || e,
 				url = o.ajax;
-			
+
 			target = (typeof target === 'string') ? $(target,e) : $(target);
 			if(url.substr(0,1) === '@') url = $(t).attr(url.substring(1));
-			
+
 			// load remote contents
 			target.load(url,function(){
 				o.onLoad && o.onLoad.call(this,h);
 			});
-			
+
 			// show modal
 			if(o.ajaxText) {
-        target.html(o.ajaxText);
-      }
-      open(h);
+                                target.html(o.ajaxText);
+                        }
+                        open(h);
 		}
 		else { open(h); }
 		
@@ -136,86 +131,84 @@
 		/**
 		 * e = modal element (as jQuery object)
 		 * t = triggering element
-		 * 
+		 *
 		 * o = options
 		 * h = hash (for jqModal <= r15 compatibility)
 		 */
-		
+
 		var o = e.data('jqm'),
 			t = t || window.event,
-		
+
 		// maintain legacy "hash" construct
 		h = {w: e, c: o, o: e.data('jqmv'), t: t};
-		
+
 		close(h);
-		
+
 	}, onShow = function(hash){
 		// onShow callback. Responsible for showing a modal and overlay.
 		//  return false to stop opening modal. 
-		
+
 		// hash object;
 		//  w: (jQuery object) The modal element
 		//  c: (object) The modal's options object 
 		//  o: (jQuery object) The overlay element
 		//  t: (DOM object) The triggering element
-		
+
 		// display the overlay (prepend to body) if not disabled
 		if(hash.c.overlay > 0)
 			hash.o.prependTo('body');
-			
+
 		// make modal visible
 		hash.w.show();
-		
+
 		// call focusFunc (attempts to focus on first input in modal)
 		$.jqm.focusFunc(hash.w,true);
-		
+
 		return true;
-		
-		
+
 	}, onHide = function(hash){
 		// onHide callback. Responsible for hiding a modal and overlay.
 		//  return false to stop closing modal. 
-		
+
 		// hash object;
 		//  w: (jQuery object) The modal element
 		//  c: (object) The modal's options object 
 		//  o: (jQuery object) The overlay element
 		//  t: (DOM object) The triggering element
-		
+
 		// hide modal and if overlay, remove overlay.
 		hash.w.hide() && hash.o && hash.o.remove();
-		
+
 		return true;
-		
-		
+
 	},  addTrigger = function(e, key, trigger){
 		// addTrigger: Adds a jqmShow/jqmHide (key) event click on modal (e)
 		//  to all elements that match trigger string (trigger)
-		
+
 		var jqm = e.data('jqm');
-		
+
 		// return false if e is not an initialized modal element
 		if(!e.data('jqm')) return false;
-		
+
 		return $(trigger).each(function(){
 			this[key] = this[key] || [];
-			
+
 			// register this modal with this trigger only once
 			if($.inArray(jqm.ID,this[key]) < 0) {
 				this[key].push(jqm.ID);
-				
+
 				// register trigger click event for this modal
 				$(this).click(function(){
-					
+
 					e[key](this);
-					
+
 					// stop trigger click event from bubbling
 					return false;
 				});
 			}
-			
+
 		});
-		
+
 	}, function(h){
 		// open: executes the onOpen callback + performs common tasks if successful
 
@@ -223,29 +216,28 @@
 		var e = h.w,
 			v = h.o,
 			o = h.c;
-		
 
 		// execute onShow callback
 		if(o.onShow(h) !== false){
 			// mark modal as shown
 			e[0]._jqmShown = true;
-			
-			// if modal dialog 
+
+			// if modal dialog
 			//
 			// Bind the Keep Focus Function [F] if no other Modals are open (!ActiveModals[0]) +
-			// 
+			//
 			// else, close dialog when overlay is clicked
 			if(o.modal){ !ActiveModals[0]&&F('bind'); ActiveModals.push(e[0]); }
 			else e.jqmAddClose(v);
-			
+
 			//  Attach closing events to elements inside the modal matching closingClass
 			o.closeClass&&e.jqmAddClose($('.' + o.closeClass,e));
-			
+
 			// IF toTop is true and overlay exists;
 			//  Add placeholder element <span id="jqmP#ID_of_modal"/> before modal to
 			//  remember it's position in the DOM and move it to a child of the body tag (after overlay)
 			o.toTop&&v&&e.before('<span id="jqmP'+o.ID+'"></span>').insertAfter(v);
-			
+
 			// remember overlay (for closing function)
 			e.data('jqmv',v);
 
@@ -255,12 +247,11 @@
 				e.attr("tabindex", 0).bind("keydown",$.jqm.closeOnEscFunc).focus();
 			}
 		}
-		
-		
+
 	}, function(h){
 		// close: executes the onHide callback + performs common tasks if successful
 
-		// transform legacy hash into new var shortcuts 
+		// transform legacy hash into new var shortcuts
 		 var e = h.w,
 			v = h.o,
 			o = h.c;
@@ -269,39 +260,36 @@
 		if(o.onHide(h) !== false){
 			// mark modal as !shown
 			e[0]._jqmShown = false;
-			
+
 			 // If modal, remove from modal stack.
 			 // If no modals in modal stack, unbind the Keep Focus Function
 			 if(o.modal){ActiveModals.pop();!ActiveModals[0]&&F('unbind');}
-			 
+
 			 // IF toTop was passed and an overlay exists;
 			 //  Move modal back to its "remembered" position.
 			 o.toTop&&v&&$('#jqmP'+o.ID).after(e).remove();
 		}
-		
-		
+
 	},  F = function(t){
 		// F: The Keep Focus Function (for modal: true dialos)
 		// Binds or Unbinds (t) the Focus Examination Function (X) to keypresses and clicks
-		
+
 		$(document)[t]("keypress keydown mousedown",X);
-		
-		
+
 	}, X = function(e){
 		// X: The Focus Examination Function (for modal: true dialogs)
 
 		var targetModal = $(e.target).data('jqm') || $(e.target).parents('.jqm-init:first').data('jqm');
 		var activeModal = ActiveModals[ActiveModals.length-1];
-		
+
 		// allow bubbling if event target is within active modal dialog
-		return (targetModal && targetModal.ID === activeModal._jqmID) ? 
+		return (targetModal && targetModal.ID === activeModal._jqmID) ?
 		  true : $.jqm.focusFunc(activeModal,e);
-	}, 
-	
-	I = 0,   // modal ID increment (for nested modals) 
+	},
+
+	I = 0,   // modal ID increment (for nested modals)
 	ActiveModals = [];  // array of active modals (used to lock interactivity to appropriate modal)
-	
-	
+
 	// $.jqm, overridable defaults
 	$.jqm = {
 		/**
@@ -336,22 +324,22 @@
 			onHide: onHide,
 			onLoad: false
 		},
-		
+
 		// focusFunc is fired:
-		//   a) when a modal:true dialog is shown, 
+		//   a) when a modal:true dialog is shown,
 		//   b) when an event occurs outside an active modal:true dialog
-		// It is passed the active modal:true dialog as well as event 
-		focusFunc: function(activeModal, event) { 
-		  
+		// It is passed the active modal:true dialog as well as event
+		focusFunc: function(activeModal, event) {
+
 		  // if the event occurs outside the activeModal, focus on first element
-		  if(event) { 
+		  if(event) {
 		    $(':input:visible:first',activeModal).focus();
-		  } 
-		  
+		  }
+
 		  // lock interactions to the activeModal
 		  return false; 
 		},
-		  
+
 		// closeOnEscFunc is attached to modals where closeOnEsc param true.
 		closeOnEscFunc: function(event){
 			if (event.keyCode === 27) {
@@ -360,5 +348,5 @@
 			}
 		}
 	};
-	
+
 })( jQuery );

--- a/jqModal.js
+++ b/jqModal.js
@@ -248,7 +248,7 @@
 			}
 		}
 
-	}, function(h){
+	}, close = function(h){
 		// close: executes the onHide callback + performs common tasks if successful
 
 		// transform legacy hash into new var shortcuts

--- a/jqModal.js
+++ b/jqModal.js
@@ -116,8 +116,8 @@
 			var target = o.target || e,
 				url = o.ajax;
 			
-			target = (typeof target == 'string') ? $(target,e) : $(target);
-			if(url.substr(0,1) == '@') url = $(t).attr(url.substring(1));
+			target = (typeof target === 'string') ? $(target,e) : $(target);
+			if(url.substr(0,1) === '@') url = $(t).attr(url.substring(1));
 			
 			// load remote contents
 			target.load(url,function(){
@@ -294,7 +294,7 @@
 		var activeModal = ActiveModals[ActiveModals.length-1];
 		
 		// allow bubbling if event target is within active modal dialog
-		return (targetModal && targetModal.ID == activeModal._jqmID) ? 
+		return (targetModal && targetModal.ID === activeModal._jqmID) ? 
 		  true : $.jqm.focusFunc(activeModal,e);
 	}, 
 	
@@ -354,7 +354,7 @@
 		  
 		// closeOnEscFunc is attached to modals where closeOnEsc param true.
 		closeOnEscFunc: function(event){
-			if (event.keyCode == 27) {
+			if (event.keyCode === 27) {
 				$(this).jqmHide();
 				return false;
 			}

--- a/jqModal.js
+++ b/jqModal.js
@@ -47,7 +47,7 @@
 	$.fn.jqmAddTrigger=function(trigger){
 		return this.each(function(){
 			if(!addTrigger($(this), 'jqmShow', trigger))
-				err("jqmAddTrigger must be called on initialized modals")
+				err("jqmAddTrigger must be called on initialized modals");
 		});
 	};
 	
@@ -62,7 +62,7 @@
 	$.fn.jqmAddClose=function(trigger){
 		return this.each(function(){
 			if(!addTrigger($(this), 'jqmHide', trigger))
-				err("jqmAddClose must be called on initialized modals")
+				err("jqmAddClose must be called on initialized modals");
 		});
 	};
 	
@@ -206,7 +206,6 @@
 				
 				// register trigger click event for this modal
 				$(this).click(function(){
-					var trigger = this;
 					
 					e[key](this);
 					
@@ -217,7 +216,7 @@
 			
 		});
 		
-	},  open = function(h){
+	}, function(h){
 		// open: executes the onOpen callback + performs common tasks if successful
 
 		// transform legacy hash into new var shortcuts 
@@ -258,7 +257,7 @@
 		}
 		
 		
-	},  close = function(h){
+	}, function(h){
 		// close: executes the onHide callback + performs common tasks if successful
 
 		// transform legacy hash into new var shortcuts 


### PR DESCRIPTION
Fix jshint described at https://integration.wikimedia.org/ci/job/mwext-AjaxLogin-jslint/11/console

22:22:02 jqModal.js: line 35, col 51, Expected an assignment or function call and instead saw an expression.
22:22:02 jqModal.js: line 50, col 74, Missing semicolon.
22:22:02 jqModal.js: line 65, col 72, Missing semicolon.
22:22:02 jqModal.js: line 74, col 76, Expected an assignment or function call and instead saw an expression.
22:22:02 jqModal.js: line 81, col 75, Expected an assignment or function call and instead saw an expression.
22:22:02 jqModal.js: line 105, col 15, 't' is already defined.
22:22:02 jqModal.js: line 107, col 15, 'z' is already defined.
22:22:02 jqModal.js: line 119, col 39, Expected '===' and instead saw '=='.
22:22:02 jqModal.js: line 120, col 34, Expected '===' and instead saw '=='.
22:22:02 jqModal.js: line 124, col 49, Expected an assignment or function call and instead saw an expression.
22:22:02 jqModal.js: line 145, col 15, 't' is already defined.
22:22:02 jqModal.js: line 186, col 50, Expected an assignment or function call and instead saw an expression.
22:22:02 jqModal.js: line 239, col 44, Missing 'new' prefix when invoking a constructor.
22:22:02 jqModal.js: line 239, col 52, Expected an assignment or function call and instead saw an expression.
22:22:02 jqModal.js: line 243, col 64, Expected an assignment or function call and instead saw an expression.
22:22:02 jqModal.js: line 248, col 82, Expected an assignment or function call and instead saw an expression.
22:22:02 jqModal.js: line 276, col 63, Missing 'new' prefix when invoking a constructor.
22:22:02 jqModal.js: line 276, col 73, Expected an assignment or function call and instead saw an expression.
22:22:02 jqModal.js: line 280, col 58, Expected an assignment or function call and instead saw an expression.
22:22:02 jqModal.js: line 298, col 49, Expected '===' and instead saw '=='.
22:22:02 jqModal.js: line 358, col 33, Expected '===' and instead saw '=='.
22:22:02 jqModal.js: line 220, col 9, 'open' is defined but never used.
22:22:02 jqModal.js: line 261, col 9, 'close' is defined but never used.
22:22:02 jqModal.js: line 209, col 25, 'trigger' is defined but never used.
