### PR TITLE
Allow click cancelation

### DIFF
--- a/jqModal.js
+++ b/jqModal.js
@@ -198,8 +198,10 @@
 				this[key].push(jqm.ID);
 
 				// register trigger click event for this modal
-				$(this).click(function(){
-
+				$(this).click(function(f){
+					// allow cancelation of event
+					if (f.isDefaultPrevented()) return false;
+					
 					e[key](this);
 
 					// stop trigger click event from bubbling


### PR DESCRIPTION
If an earlier click handler occurs, and it prevents default, the jqm click handler is cancelled. This is to prevent ajax loading of dialogs if user wants to cancel event.