### PR TITLE
bypass events to jQuery UI Datepicker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@
 /.classpath
 /.buildpath
 /.settings/
+/.idea
 
-
-
-
+# as lib it ignores the package-lock
+/package-lock.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 jqModal Changes By Release
 ==========================
 
+## 1.4.2 (2016.04.24 +r27.1)
+* allow exclusions for elements which are children of .blockMsg
+
 ## 1.4.2 (2016.04.16 +r27)
 
 * restore parsing and assigning closeClass behavior in ajax loaded content

--- a/jqModal.js
+++ b/jqModal.js
@@ -320,7 +320,7 @@
 
 		var $target = $(e.target), 
 				targetModal = $target.data('jqm') ||
-		                  $.target.parents('.jqm-init:first').data('jqm');
+		                  $target.parents('.jqm-init:first').data('jqm');
 		var activeModal = ActiveModals[ActiveModals.length-1],
 				activeModalOpts = $(activeModal).data('jqm');
 

--- a/jqModal.js
+++ b/jqModal.js
@@ -6,7 +6,7 @@
  *   http://www.opensource.org/licenses/mit-license.php
  *   http://www.gnu.org/licenses/gpl.html
  *
- * $Version: 1.4.2 (2016.04.16 +r27)
+ * $Version: 1.4.2 (2016.04.16 +r27a, patched)
  * Requires: jQuery 1.2.3+
  */
 
@@ -318,9 +318,16 @@
 	}, X = function(e){
 		// X: The Focus Examination Function (for modal: true dialogs)
 
-		var targetModal = $(e.target).data('jqm') ||
-		                  $(e.target).parents('.jqm-init:first').data('jqm');
-		var activeModal = ActiveModals[ActiveModals.length-1];
+		var $target = $(e.target), 
+				targetModal = $target.data('jqm') ||
+		                  $.target.parents('.jqm-init:first').data('jqm');
+		var activeModal = ActiveModals[ActiveModals.length-1],
+				activeModalOpts = $(activeModal).data('jqm');
+
+		// allow all elements with parents.blockMsgClass (used for jqui datepicker)
+		if ($target.parents('.'+activeModalOpts.blockMsgClass).length > 0) {
+			return true;
+		}
 
 		// allow bubbling if event target is within active modal dialog
 		return (targetModal && targetModal.ID === activeModal._jqmID) ?
@@ -356,6 +363,7 @@
 		 * (Function)  onShow       - User defined callback function fired when modal opened.
 		 * (Function)  onHide       - User defined callback function fired when modal closed.
 		 * (Function)  onLoad       - User defined callback function fired when ajax content loads.
+		 * (String)		 blockMsgClass- User defined exclusion parent class which are allowed to get focus even outside the active modal
 		 */
 		params: {
 			overlay: 50,
@@ -370,7 +378,8 @@
 			toTop: false,
 			onShow: onShow,
 			onHide: onHide,
-			onLoad: false
+			onLoad: false,
+			blockMsgClass: 'blockMsg'
 		},
 
 		// focusFunc is fired:

--- a/jqModal.js
+++ b/jqModal.js
@@ -363,7 +363,7 @@
 		 * (Function)  onShow       - User defined callback function fired when modal opened.
 		 * (Function)  onHide       - User defined callback function fired when modal closed.
 		 * (Function)  onLoad       - User defined callback function fired when ajax content loads.
-		 * (String)		 blockMsgClass- User defined exclusion parent class which are allowed to get focus even outside the active modal
+		 * (String)		 blockMsgClass- User defined exclusion parent class which are allowed to get focus even outside the active modal (like the jQueryUI datepicker)
 		 */
 		params: {
 			overlay: 50,


### PR DESCRIPTION
The following patch allows to bypass events/focus to elements outside of an active modal. This happens when you use a jQuery UI Datepicker in a jqModal overlay with `modal: true`. Then the year could not be changed any more, because the select won't be able to get the focus.

I've found the problem and solution here: http://stackoverflow.com/a/18188375/2627857 and adopted it for jqModal.

We call our modal now like this:

``` js
$element.jqm({
          modal: true,
          blockMsgClass: 'ui-datepicker'
          }
```

which allows us to use the ui-datepicker inside the modal. It would be very kind if you could accept or implement it in jqModal. Sorry for my rusty english
